### PR TITLE
Small safari layout fix

### DIFF
--- a/src/scss/boxes.scss
+++ b/src/scss/boxes.scss
@@ -6,13 +6,9 @@
   // display: inline-block;
    display: flex;
   display: -webkit-flex;
- 
- 
-
-
   filter: url(#semiround);
   position: relative;
-
+  
   &::before {
     transition: 0.5s ease;
 
@@ -46,10 +42,14 @@
         top right;
     mask-size: 50.5% 50.5%;
     mask-repeat: no-repeat;
-    z-index: -1;
   }
+
+  & > a {
+    z-index: 1;
+  }
+
   &.rounded {
-    filter: url(#round);
+    filter: url(#round); 
   }
 
   .overlay {


### PR DESCRIPTION
Small fix for safari desktop to fix the issue with rounded corners

<img width="1581" alt="image" src="https://github.com/user-attachments/assets/88d71506-6704-4829-8f2c-e866f1839859" />

Still need to look into mobile. Need to talk with David about that.